### PR TITLE
Fix setup.sh bug and the description of updating crontab in the webpage index.php

### DIFF
--- a/app/index.php
+++ b/app/index.php
@@ -134,10 +134,8 @@
         </div>
 
         <h2>Update Crontab:</h2>
-        <h4>1) Note that currently ONLY ONE LINE is supported, adding a new one will rewrite the old one.</h4>
-        <h4>2) Update with blank to remove the line.</h4>
-        <h4>3) Format: min hour day_of_month month day_of_week</h4>
-        <h4>4) For execute every minute, type "* * * * *"</h4>
+        <h4>Format: min hour day_of_month month day_of_week</h4>
+        <h4>To execute every minute, type "* * * * *"</h4>
         <form method="post" action="" class="form">
             <label for="crontab">Crontab Entry:</label>
             <input type="text" id="crontab" name="crontab"><br>

--- a/setup.sh
+++ b/setup.sh
@@ -2,16 +2,25 @@
 
 
 # Create the file to store log
-LOG_FILE=./app/script/.env
-touch "$LOG_FILE"
-echo 'record="sub.domain.tld"' >> "$LOG_FILE"
-echo 'zone_id=""' >> "$LOG_FILE"
-echo 'token=""' >> "$LOG_FILE"
-echo 'email=""' >> "$LOG_FILE"
-echo 'proxy="true"' >> "$LOG_FILE"
-echo 'ttl="60"' >> "$LOG_FILE"
+CONF_FILE=./app/script/.env
+echo "Thank you for choosing cloudflare-ddns-webGUI!"
+echo "The conig file is stored in ./app/script/.eng"
+if [ -f "$CONF_FILE" ]; then
+    rm "$CONF_FILE"
+    echo "Old file found, deleting it..."
+fi
+touch "$CONF_FILE"
+echo "Creating the config file and add empty config to it..."
+echo 'record="sub.domain.tld"' >> "$CONF_FILE"
+echo 'zone_id=""' >> "$CONF_FILE"
+echo 'token=""' >> "$CONF_FILE"
+echo 'email=""' >> "$CONF_FILE"
+echo 'proxy="true"' >> "$CONF_FILE"
+echo 'ttl="60"' >> "$CONF_FILE"
 
 # Set permission to the app folder
+echo "Setting permission to the app folder"
 chmod -R 777 ./app 
 
+echo "Now docker compose up, with detach parameter (-d)."
 docker compose up -d


### PR DESCRIPTION
1. Setup.sh

     Fixed the setup.sh bug where if a user were to execute multiple times the configs of .env config file will be duplicated.

     Fixed the variable used in the script from $LOG_FILE to $CONF_FILE, caused by my careless mistake.

2. index.php

     Fixed the description of updating crontab of the webpage. 